### PR TITLE
[Fix] JwtAuthenticationFilter에 validateToken() 검증 로직 추가 (#80)

### DIFF
--- a/src/main/java/kr/co/ync/projectA/global/jwt/JwtProvider.java
+++ b/src/main/java/kr/co/ync/projectA/global/jwt/JwtProvider.java
@@ -142,6 +142,25 @@ public class JwtProvider {
         );
     }
 
+    /**
+     * 📌 JWT 유효성 검증
+     *  - 토큰이 만료되었거나 서명이 올바르지 않으면 false 반환
+     *  - 유효할 경우 true 반환
+     */
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token); // 내부적으로 Jwts.parser()를 실행해 서명과 만료 여부 검증
+            return true;
+        } catch (JwtException e) {
+            System.out.println("❌ JWT 검증 실패: " + e.getMessage());
+            return false;
+        } catch (IllegalArgumentException e) {
+            System.out.println("❌ 잘못된 JWT 토큰 형식: " + e.getMessage());
+            return false;
+        }
+    }
+
+
     // (선택) 토큰에서 이메일만 뽑고 싶을 때 간단 유틸
     @Nullable
     public String extractEmailOrNull(String token) {

--- a/src/main/java/kr/co/ync/projectA/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/ync/projectA/global/jwt/filter/JwtAuthenticationFilter.java
@@ -48,9 +48,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         if (token != null) {
-            Authentication authentication = jwtProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            // ✅ 1. 토큰 유효성 먼저 검증
+            if (jwtProvider.validateToken(token)) {
+                Authentication authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.info("✅ JWT 인증 성공: {}", authentication.getName());
+            } else {
+                log.warn("❌ 유효하지 않은 JWT 토큰 - 인증 객체를 설정하지 않음");
+            }
         }
+
 
         filterChain.doFilter(request, response);
     }


### PR DESCRIPTION
### 🧰 **구현 내용**
- `JwtProvider`에 `validateToken()` 메서드 추가  
  - 내부적으로 `getClaims()` 실행 후 예외 캐치하여 유효성 검증 수행  
- `JwtAuthenticationFilter`에서  
  - `jwtProvider.validateToken()` 호출 후 `true`일 때만 인증 객체 등록  
  - 잘못된 토큰의 경우 SecurityContext 미설정 및 경고 로그 출력  
- 로깅 강화 (`✅ JWT 인증 성공`, `❌ 유효하지 않은 JWT 토큰`)

---

### ** 관련 이슈 **
Closes #80 