### PR TITLE
[Feat] 비로그인 사용자의 레스토랑 목록 및 상세 조회 허용 (#88)

### DIFF
--- a/src/main/java/kr/co/ync/projectA/global/security/config/SecurityConfig.java
+++ b/src/main/java/kr/co/ync/projectA/global/security/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         authorize
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                 .requestMatchers("/auth/**", "/api/members/register").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/restaurants/**").permitAll()
                                 .requestMatchers("/api/mypage/**").authenticated()
                                 .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 🧰 주요 수정 내용
- `SecurityConfig`의 `authorizeHttpRequests()` 설정 수정  
  - `HttpMethod.GET, "/api/restaurants/**"` 경로에 대해 `permitAll()` 적용  
  - 나머지 `POST`, `PUT`, `DELETE` 요청은 기존대로 인증 필요  
- `SecurityFilterChain` 로드 시 디버깅용 로그 유지 (`✅ Custom SecurityFilterChain initialized`)  
- `/api/mypage/**`, `/api/auth/**` 등의 기존 인증 설정 영향 없음  

--

## 관련 이슈
Closes #88 

