### PR TITLE
[Feat]레스토랑 검색 및 필터링 기능 구현 (#92)

### DIFF
--- a/src/main/java/kr/co/ync/projectA/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurant/controller/RestaurantController.java
@@ -10,8 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/restaurants")
 @RequiredArgsConstructor
@@ -19,29 +17,37 @@ public class RestaurantController {
 
     private final RestaurantService restaurantService;
 
-    /** 등록 */
+    /** ✅ 가게 등록 */
     @PreAuthorize("permitAll()")
     @PostMapping
     public ResponseEntity<RestaurantResponse> register(@RequestBody RestaurantRequest request) {
         return ResponseEntity.ok(restaurantService.register(request));
     }
 
-    /** 전체 조회 */
+    /** ✅ 통합 조회 (검색 + 필터 + 전체 조회)
+     * 프론트에서 아래 형태로 요청:
+     *   /api/restaurants?keyword=ラーメン&region=東京都&category=和食
+     */
     @GetMapping
-    public ResponseEntity<Page<RestaurantResponse>> getAll(
+    public ResponseEntity<Page<RestaurantResponse>> getRestaurants(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String region,
+            @RequestParam(required = false) String category,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(restaurantService.getAll(PageRequest.of(page, size)));
+        return ResponseEntity.ok(
+                restaurantService.searchRestaurants(keyword, region, category, PageRequest.of(page, size))
+        );
     }
 
-    /** 상세 조회 */
+    /** ✅ 상세 조회 */
     @GetMapping("/{id}")
     public ResponseEntity<RestaurantResponse> getById(@PathVariable Long id) {
         return ResponseEntity.ok(restaurantService.getById(id));
     }
 
-    /** 수정 */
+    /** ✅ 수정 */
     @PutMapping("/{id}")
     public ResponseEntity<RestaurantResponse> update(
             @PathVariable Long id,
@@ -50,32 +56,10 @@ public class RestaurantController {
         return ResponseEntity.ok(restaurantService.update(id, request));
     }
 
-    /** 삭제 */
+    /** ✅ 삭제 */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         restaurantService.delete(id);
         return ResponseEntity.noContent().build();
-    }
-
-    /** 지역별 조회 */
-    @GetMapping("/area/{area}")
-    public ResponseEntity<List<RestaurantResponse>> getByArea(@PathVariable String area) {
-        return ResponseEntity.ok(restaurantService.getByArea(area));
-    }
-
-    /** 이름 검색 */
-    @GetMapping("/search")
-    public ResponseEntity<List<RestaurantResponse>> searchByName(@RequestParam String keyword) {
-        return ResponseEntity.ok(restaurantService.searchByName(keyword));
-    }
-
-    /** 카테고리별 조회 */
-    @GetMapping("/category/{category}")
-    public ResponseEntity<Page<RestaurantResponse>> getByCategory(
-            @PathVariable String category,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
-    ) {
-        return ResponseEntity.ok(restaurantService.getByCategory(category, PageRequest.of(page, size)));
     }
 }

--- a/src/main/java/kr/co/ync/projectA/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurant/repository/RestaurantRepository.java
@@ -3,39 +3,38 @@ package kr.co.ync.projectA.domain.restaurant.repository;
 import kr.co.ync.projectA.domain.restaurant.entity.RestaurantEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface RestaurantRepository extends JpaRepository<RestaurantEntity, Long> {
 
-    // 지역별 조회
-    List<RestaurantEntity> findByArea(String area);
-
-    // 이름 검색
-    List<RestaurantEntity> findByNameContaining(String keyword);
-
-    // 카테고리별 조회 (카테고리 조인)
-    @Query(
-            value = """
-            select distinct r
-            from RestaurantEntity r
-            join r.categoryMappings m
-            join m.category c
-            where c.name = :categoryName
-        """,
-            countQuery = """
-            select count(distinct r)
-            from RestaurantEntity r
-            join r.categoryMappings m
-            join m.category c
-            where c.name = :categoryName
-        """
-    )
-    Page<RestaurantEntity> findByCategoryName(@Param("categoryName") String categoryName, Pageable pageable);
+    /**
+     * ✅ 통합 검색 / 필터링 쿼리 (JPQL)
+     *
+     * 프론트에서 /api/restaurants?keyword=ラーメン&region=東京都&category=和食
+     * 이런 형태로 요청 시 작동합니다.
+     *
+     * - keyword: 가게명(name) 또는 주소(address)에 포함된 문자열 검색
+     * - region: 주소(address)에 지역명 포함 시 매칭
+     * - category: 카테고리 이름이 일치하는 경우 매칭
+     *
+     * 3개 중 하나라도 null이면 해당 조건은 자동으로 무시됩니다.
+     */
+    @Query("""
+        SELECT DISTINCT r
+        FROM RestaurantEntity r
+        LEFT JOIN r.categoryMappings m
+        LEFT JOIN m.category c
+        WHERE (:keyword IS NULL OR r.name LIKE %:keyword% OR r.address LIKE %:keyword%)
+        AND (:region IS NULL OR r.address LIKE %:region%)
+        AND (:category IS NULL OR c.name = :category)
+    """)
+    Page<RestaurantEntity> findByConditions(
+            @Param("keyword") String keyword,
+            @Param("region") String region,
+            @Param("category") String category,
+            Pageable pageable
+    );
 }
-


### PR DESCRIPTION
## 🧩 개요
기존에 분리되어 있던 지역별, 카테고리별, 이름 검색 API를 하나로 통합했습니다.  
프론트엔드의 통합 요청 형식(`/api/restaurants?keyword=&region=&category=`)에 대응하도록  
조건부 검색 기능을 구현했습니다.  
빈 필터는 자동으로 무시되며, 선택된 조건만 AND 연산으로 적용됩니다.

---

## ⚙️ 주요 구현 내용
- **RestaurantController**
  - `/api/restaurants` 단일 엔드포인트로 검색/필터/전체 조회 통합
  - `@RequestParam`으로 `keyword`, `region`, `category`를 받아 `RestaurantService`로 전달

- **RestaurantService**
  - 빈 문자열(`""`)을 null로 변환하여 조건 누락 방지
  - 모든 파라미터가 null이면 전체 조회 수행
  - Mapper를 사용해 `RestaurantResponse`로 변환

- **RestaurantRepository**
  - `findByConditions()` JPQL 쿼리 추가  
    ```java
    SELECT DISTINCT r
    FROM RestaurantEntity r
    LEFT JOIN r.categoryMappings m
    LEFT JOIN m.category c
    WHERE (:keyword IS NULL OR r.name LIKE %:keyword% OR r.address LIKE %:keyword%)
    AND (:region IS NULL OR r.address LIKE %:region%)
    AND (:category IS NULL OR c.name = :category)
    ```
  - 기존 `findByArea()`, `findByNameContaining()`, `findByCategoryName()` 메서드 제거

---

## 관련 이슈
Closes #92 