### PR TITLE
[Feat] 식당 등록/수정 시 카테고리 매핑 로직 안정화 (#95)

### DIFF
--- a/src/main/java/kr/co/ync/projectA/domain/restaurant/dto/request/RestaurantRequest.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurant/dto/request/RestaurantRequest.java
@@ -1,16 +1,25 @@
 package kr.co.ync.projectA.domain.restaurant.dto.request;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
+/**
+ * ✅ 식당 등록 및 수정 요청 DTO
+ * 프론트엔드에서 전달받은 식당 정보 + 카테고리 ID 목록을 포함
+ */
 @Getter
 @Setter
-@NoArgsConstructor
 public class RestaurantRequest {
+
     private String name;
     private String address;
     private String area;
     private String phone;
-    private String image;
+    private String description;
+    private String image; // (이미지 필드 이미 있으면 유지)
+
+    /** ✅ 선택된 카테고리 ID 목록 */
+    private List<Long> categoryIds;
 }

--- a/src/main/java/kr/co/ync/projectA/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurant/service/RestaurantService.java
@@ -1,5 +1,7 @@
 package kr.co.ync.projectA.domain.restaurant.service;
 
+import kr.co.ync.projectA.domain.category.entity.CategoryEntity;
+import kr.co.ync.projectA.domain.category.repository.CategoryRepository;
 import kr.co.ync.projectA.domain.member.entity.MemberEntity;
 import kr.co.ync.projectA.domain.member.repository.MemberRepository;
 import kr.co.ync.projectA.domain.restaurant.dto.request.RestaurantRequest;
@@ -7,6 +9,8 @@ import kr.co.ync.projectA.domain.restaurant.dto.response.RestaurantResponse;
 import kr.co.ync.projectA.domain.restaurant.entity.RestaurantEntity;
 import kr.co.ync.projectA.domain.restaurant.mapper.RestaurantMapper;
 import kr.co.ync.projectA.domain.restaurant.repository.RestaurantRepository;
+import kr.co.ync.projectA.domain.restaurantCategoryMapEntity.entity.RestaurantCategoryMapEntity;
+import kr.co.ync.projectA.domain.restaurantCategoryMapEntity.repository.RestaurantCategoryMapRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -14,6 +18,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+/**
+ * ✅ RestaurantService
+ * 식당 등록, 수정, 조회, 삭제를 담당.
+ * 카테고리 매핑 로직 포함 (tbl_restaurant_category_map)
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,47 +32,51 @@ public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
     private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+    private final RestaurantCategoryMapRepository restaurantCategoryMapRepository;
 
     /** ✅ 식당 등록 */
     @Transactional
     public RestaurantResponse register(RestaurantRequest request) {
-        // TODO: JWT 인증 연결 후 실제 로그인 유저 사용 예정
+        // ⚙️ TODO: JWT 인증 연결 후 실제 로그인 유저로 교체 예정
         MemberEntity owner = memberRepository.findById(1L)
                 .orElseThrow(() -> new RuntimeException("회원 정보를 찾을 수 없습니다."));
 
-        RestaurantEntity entity = RestaurantMapper.toEntity(request, owner);
-        RestaurantEntity saved = restaurantRepository.save(entity);
-        return RestaurantMapper.toResponse(saved);
+        // ✅ 식당 엔티티 생성 및 저장
+        RestaurantEntity restaurant = RestaurantMapper.toEntity(request, owner);
+        RestaurantEntity savedRestaurant = restaurantRepository.save(restaurant);
+
+        // ✅ 선택된 카테고리 매핑 처리
+        if (request.getCategoryIds() != null && !request.getCategoryIds().isEmpty()) {
+            List<CategoryEntity> categories = categoryRepository.findAllById(request.getCategoryIds());
+
+            List<RestaurantCategoryMapEntity> mappings = categories.stream()
+                    .map(category -> RestaurantCategoryMapEntity.builder()
+                            .restaurant(savedRestaurant)
+                            .category(category)
+                            .build())
+                    .toList();
+
+            restaurantCategoryMapRepository.saveAll(mappings);
+        }
+
+        return RestaurantMapper.toResponse(savedRestaurant);
     }
 
-    /** ✅ 통합 조회 (검색 + 필터 + 전체)
-     *  프론트에서 아래 형태로 요청:
-     *  /api/restaurants?keyword=ラーメン&region=東京都&category=和食
-     */
-    public Page<RestaurantResponse> searchRestaurants(
-            String keyword,
-            String region,
-            String category,
-            Pageable pageable
-    ) {
-        // 빈 문자열("")이면 null 처리 → JPQL에서 조건 무시
+    /** ✅ 식당 통합 검색 (키워드 + 지역 + 카테고리) */
+    public Page<RestaurantResponse> searchRestaurants(String keyword, String region, String category, Pageable pageable) {
         if (keyword != null && keyword.trim().isEmpty()) keyword = null;
         if (region != null && region.trim().isEmpty()) region = null;
         if (category != null && category.trim().isEmpty()) category = null;
 
-        Page<RestaurantEntity> restaurants;
-
-        // 모든 필터가 비어 있으면 전체 조회
-        if (keyword == null && region == null && category == null) {
-            restaurants = restaurantRepository.findAll(pageable);
-        } else {
-            restaurants = restaurantRepository.findByConditions(keyword, region, category, pageable);
-        }
+        Page<RestaurantEntity> restaurants = (keyword == null && region == null && category == null)
+                ? restaurantRepository.findAll(pageable)
+                : restaurantRepository.findByConditions(keyword, region, category, pageable);
 
         return restaurants.map(RestaurantMapper::toResponse);
     }
 
-    /** ✅ 전체 조회 (기존 유지 — 필요 시 단독 호출 가능) */
+    /** ✅ 전체 조회 */
     public Page<RestaurantResponse> getAll(PageRequest pageRequest) {
         return restaurantRepository.findAll(pageRequest)
                 .map(RestaurantMapper::toResponse);
@@ -74,7 +89,7 @@ public class RestaurantService {
         return RestaurantMapper.toResponse(restaurant);
     }
 
-    /** ✅ 수정 */
+    /** ✅ 수정 (카테고리 재매핑 포함) */
     @Transactional
     public RestaurantResponse update(Long id, RestaurantRequest request) {
         RestaurantEntity entity = restaurantRepository.findById(id)
@@ -89,12 +104,30 @@ public class RestaurantService {
         );
 
         RestaurantEntity saved = restaurantRepository.save(entity);
+
+        // ✅ 기존 카테고리 매핑 전체 삭제
+        restaurantCategoryMapRepository.deleteByRestaurantId(id);
+
+        // ✅ 새 카테고리 매핑 등록
+        if (request.getCategoryIds() != null && !request.getCategoryIds().isEmpty()) {
+            List<CategoryEntity> categories = categoryRepository.findAllById(request.getCategoryIds());
+            List<RestaurantCategoryMapEntity> newMappings = categories.stream()
+                    .map(cat -> RestaurantCategoryMapEntity.builder()
+                            .restaurant(saved)
+                            .category(cat)
+                            .build())
+                    .toList();
+            restaurantCategoryMapRepository.saveAll(newMappings);
+        }
+
         return RestaurantMapper.toResponse(saved);
     }
 
     /** ✅ 삭제 */
     @Transactional
     public void delete(Long id) {
+        // ✅ 매핑 먼저 삭제 후 식당 삭제 (안전하게)
+        restaurantCategoryMapRepository.deleteByRestaurantId(id);
         restaurantRepository.deleteById(id);
     }
 }

--- a/src/main/java/kr/co/ync/projectA/domain/restaurantCategoryMapEntity/repository/RestaurantCategoryMapRepository.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurantCategoryMapEntity/repository/RestaurantCategoryMapRepository.java
@@ -1,7 +1,19 @@
 package kr.co.ync.projectA.domain.restaurantCategoryMapEntity.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import kr.co.ync.projectA.domain.restaurantCategoryMapEntity.entity.RestaurantCategoryMapEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
 
+/**
+ * ✅ 식당-카테고리 매핑 테이블 Repository
+ */
+@Repository
 public interface RestaurantCategoryMapRepository extends JpaRepository<RestaurantCategoryMapEntity, Long> {
+
+    /** 특정 식당의 모든 매핑 삭제 */
+    void deleteByRestaurantId(Long restaurantId);
+
+    /** 특정 식당의 매핑 전체 조회 (필요 시 사용) */
+    List<RestaurantCategoryMapEntity> findByRestaurantId(Long restaurantId);
 }


### PR DESCRIPTION
## 🧩 주요 구현 내용
1. **RestaurantRequest DTO 수정**
   - `List<Long> categoryIds` 필드 추가  
     → 프론트엔드에서 선택된 카테고리 ID 배열 전달 가능

2. **RestaurantService 수정**
   - 식당 등록 시 `categoryIds`를 기반으로  
     `RestaurantCategoryMapEntity` 매핑 데이터 생성 및 저장
   - 수정 시 `deleteByRestaurantId()`를 이용해 기존 매핑 삭제 후 재등록
   - 삭제 시 매핑 테이블 데이터도 함께 삭제 처리

3. **RestaurantCategoryMapRepository 수정**
   - `deleteByRestaurantId(Long restaurantId)` 메서드 추가 (성능 개선)
   - `findByRestaurantId(Long restaurantId)` 조회 메서드 추가 (확장성 확보)

4. **트랜잭션 처리 강화**
   - `@Transactional` 사용으로 등록/수정/삭제 과정 전체 원자성 보장

---

## 관련 이슈
Closes #95 