### PR TITLE
[Feat] 리뷰 개수 동적 계산 기능 (#140)

### DIFF
--- a/src/main/java/kr/co/ync/projectA/domain/restaurant/dto/response/RestaurantResponse.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurant/dto/response/RestaurantResponse.java
@@ -22,6 +22,7 @@ public class RestaurantResponse {
     private String image;
     private Double averageRating;
     private List<String> categoryNames;
+    private int reviewCount;
 
     public static RestaurantResponse fromEntity(RestaurantEntity entity) {
         return RestaurantResponse.builder()

--- a/src/main/java/kr/co/ync/projectA/domain/restaurant/mapper/RestaurantMapper.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurant/mapper/RestaurantMapper.java
@@ -39,4 +39,26 @@ public class RestaurantMapper {
                 .averageRating(entity.getAverageRating())
                 .build();
     }
+
+    public static RestaurantResponse toResponse(RestaurantEntity entity, int reviewCount) {
+        List<String> categoryNames = entity.getCategoryMappings() == null
+                ? List.of()
+                : entity.getCategoryMappings().stream()
+                .map(mapping -> mapping.getCategory().getName())
+                .toList();
+
+        return RestaurantResponse.builder()
+                .id(entity.getId())
+                .ownerId(entity.getOwner().getId())
+                .ownerEmail(entity.getOwner().getEmail())
+                .name(entity.getName())
+                .address(entity.getAddress())
+                .area(entity.getArea())
+                .phone(entity.getPhone())
+                .image(entity.getImage())
+                .categoryNames(categoryNames)
+                .averageRating(entity.getAverageRating())
+                .reviewCount(reviewCount)
+                .build();
+    }
 }

--- a/src/main/java/kr/co/ync/projectA/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurant/service/RestaurantService.java
@@ -7,6 +7,7 @@ import kr.co.ync.projectA.domain.restaurant.dto.response.RestaurantResponse;
 import kr.co.ync.projectA.domain.restaurant.entity.RestaurantEntity;
 import kr.co.ync.projectA.domain.restaurant.mapper.RestaurantMapper;
 import kr.co.ync.projectA.domain.restaurant.repository.RestaurantRepository;
+import kr.co.ync.projectA.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +30,7 @@ public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
     private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
 
     /** ✅ 식당 등록 */
     @Transactional
@@ -53,7 +55,9 @@ public class RestaurantService {
     public RestaurantResponse getById(Long id) {
         RestaurantEntity restaurant = restaurantRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("식당을 찾을 수 없습니다."));
-        return RestaurantMapper.toResponse(restaurant);
+        int reviewCount = reviewRepository.countByRestaurantId(id);
+
+        return RestaurantMapper.toResponse(restaurant, reviewCount);
     }
 
     /** ✅ 수정 */

--- a/src/main/java/kr/co/ync/projectA/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/kr/co/ync/projectA/domain/review/repository/ReviewRepository.java
@@ -19,6 +19,8 @@ public interface ReviewRepository extends JpaRepository<ReviewEntity, Long> {
 
     int countByMember(MemberEntity member);
 
+    int countByRestaurantId(Long restaurantId);
+
     // ✅ 필드명이 restaurantId니까, 여기 이름도 restaurantId로
     List<ReviewEntity> findByRestaurantId(RestaurantEntity restaurant);
 


### PR DESCRIPTION
## 🔨 주요 구현 내용
- **RestaurantService**
  - `getById()` 내에서 `reviewRepository.countByRestaurantId(id)` 호출 추가
  - 리뷰 개수를 계산 후 `RestaurantMapper.toResponse(restaurant, reviewCount)`로 DTO 변환
  - 중복되던 `getRestaurantDetail()` 메서드 제거
- **RestaurantMapper**
  - `toResponse(RestaurantEntity, int reviewCount)` 오버로드 추가  
    (리뷰 개수를 DTO에 포함하여 응답)
- **RestaurantResponse**
  - `reviewCount` 필드 추가 (DB 저장 X, 응답 전용)

## 관련 이슈
Closes #140 
