### PR TITLE
[Feat] 레스토랑 요일별 영업시간 관리 기능 추가 (#175)

### DIFF
--- a/src/main/java/kr/co/ync/projectA/domain/restaurantHours/controller/RestaurantHoursController.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurantHours/controller/RestaurantHoursController.java
@@ -1,0 +1,58 @@
+package kr.co.ync.projectA.domain.restaurantHours.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.*;
+
+import kr.co.ync.projectA.domain.restaurantHours.dto.request.RestaurantHoursActiveRequest;
+import kr.co.ync.projectA.domain.restaurantHours.dto.request.RestaurantHoursRequest;
+import kr.co.ync.projectA.domain.restaurantHours.dto.response.RestaurantHoursResponse;
+import kr.co.ync.projectA.domain.restaurantHours.enums.DayOfWeekType;
+import kr.co.ync.projectA.domain.restaurantHours.service.RestaurantHoursService;
+import lombok.RequiredArgsConstructor;
+
+// 레스토랑 요일별 운영 시간 관련 API 컨트롤러
+@RestController
+@RequestMapping("/api/restaurants/{restaurantId}/hours")
+@RequiredArgsConstructor
+public class RestaurantHoursController {
+
+    private final RestaurantHoursService restaurantHoursService;
+
+    // 요일별 운영 시간 조회
+    @GetMapping
+    public List<RestaurantHoursResponse> getRestaurantHours(
+            @PathVariable Long restaurantId
+    ) {
+        return restaurantHoursService.getHours(restaurantId);
+    }
+
+    // 요일별 운영 시간 등록 (초기 세팅)
+    @PostMapping
+    public void initRestaurantHours(
+            @PathVariable Long restaurantId,
+            @RequestBody List<RestaurantHoursRequest> requests
+    ) {
+        restaurantHoursService.initHours(restaurantId, requests);
+    }
+
+    // 요일별 운영 시간 수정
+    @PutMapping("/{dayOfWeek}")
+    public RestaurantHoursResponse updateRestaurantHours(
+            @PathVariable Long restaurantId,
+            @PathVariable DayOfWeekType dayOfWeek,
+            @RequestBody RestaurantHoursRequest request
+    ) {
+        return restaurantHoursService.updateHours(restaurantId, dayOfWeek, request);
+    }
+
+    // 요일별 운영 시간 활성/비활성 (휴무 설정)
+    @PatchMapping("/{dayOfWeek}/active")
+    public RestaurantHoursResponse updateRestaurantHoursActive(
+            @PathVariable Long restaurantId,
+            @PathVariable DayOfWeekType dayOfWeek,
+            @RequestBody RestaurantHoursActiveRequest request
+    ) {
+        return restaurantHoursService.updateActive(restaurantId, dayOfWeek, request);
+    }
+}

--- a/src/main/java/kr/co/ync/projectA/domain/restaurantHours/dto/request/RestaurantHoursActiveRequest.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurantHours/dto/request/RestaurantHoursActiveRequest.java
@@ -1,0 +1,12 @@
+package kr.co.ync.projectA.domain.restaurantHours.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RestaurantHoursActiveRequest {
+    private Boolean isOpen;
+}

--- a/src/main/java/kr/co/ync/projectA/domain/restaurantHours/dto/request/RestaurantHoursRequest.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurantHours/dto/request/RestaurantHoursRequest.java
@@ -1,0 +1,20 @@
+package kr.co.ync.projectA.domain.restaurantHours.dto.request;
+
+import kr.co.ync.projectA.domain.restaurantHours.enums.DayOfWeekType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RestaurantHoursRequest {
+    private DayOfWeekType dayOfWeek;
+    private LocalTime openTime;
+    private LocalTime closeTime;
+    private Boolean isOpen;
+}

--- a/src/main/java/kr/co/ync/projectA/domain/restaurantHours/dto/response/RestaurantHoursResponse.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurantHours/dto/response/RestaurantHoursResponse.java
@@ -1,0 +1,29 @@
+package kr.co.ync.projectA.domain.restaurantHours.dto.response;
+
+import kr.co.ync.projectA.domain.restaurantHours.entity.RestaurantHoursEntity;
+import kr.co.ync.projectA.domain.restaurantHours.enums.DayOfWeekType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RestaurantHoursResponse {
+
+    private DayOfWeekType dayOfWeek;
+    private LocalTime openTime;
+    private LocalTime closeTime;
+    private Boolean isOpen;
+
+    public static RestaurantHoursResponse fromEntity(RestaurantHoursEntity entity) {
+        return RestaurantHoursResponse.builder()
+                .dayOfWeek(entity.getDayOfWeek())
+                .openTime(entity.getOpenTime())
+                .closeTime(entity.getCloseTime())
+                .isOpen(entity.getIsOpen())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/ync/projectA/domain/restaurantHours/entity/RestaurantHoursEntity.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurantHours/entity/RestaurantHoursEntity.java
@@ -36,4 +36,13 @@ public class RestaurantHoursEntity {
     @Column(nullable = false)
     private Boolean isOpen;
 
+    public void updateHours(LocalTime openTime, LocalTime closeTime, Boolean isOpen) {
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.isOpen = isOpen;
+    }
+
+    public void updateActive(Boolean isOpen) {
+        this.isOpen = isOpen;
+    }
 }

--- a/src/main/java/kr/co/ync/projectA/domain/restaurantHours/repository/RestaurantHoursRepository.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurantHours/repository/RestaurantHoursRepository.java
@@ -1,7 +1,14 @@
 package kr.co.ync.projectA.domain.restaurantHours.repository;
 
+import kr.co.ync.projectA.domain.restaurantHours.enums.DayOfWeekType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import kr.co.ync.projectA.domain.restaurantHours.entity.RestaurantHoursEntity;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface RestaurantHoursRepository extends JpaRepository<RestaurantHoursEntity, Long> {
+    List<RestaurantHoursEntity> findByRestaurant_Id(Long restaurantId);
+
+    Optional<RestaurantHoursEntity> findByRestaurant_IdAndDayOfWeek(Long restaurantId, DayOfWeekType dayOfWeek);
 }

--- a/src/main/java/kr/co/ync/projectA/domain/restaurantHours/service/RestaurantHoursService.java
+++ b/src/main/java/kr/co/ync/projectA/domain/restaurantHours/service/RestaurantHoursService.java
@@ -1,0 +1,102 @@
+package kr.co.ync.projectA.domain.restaurantHours.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.ync.projectA.domain.restaurant.entity.RestaurantEntity;
+import kr.co.ync.projectA.domain.restaurant.repository.RestaurantRepository;
+import kr.co.ync.projectA.domain.restaurantHours.dto.request.RestaurantHoursActiveRequest;
+import kr.co.ync.projectA.domain.restaurantHours.dto.request.RestaurantHoursRequest;
+import kr.co.ync.projectA.domain.restaurantHours.dto.response.RestaurantHoursResponse;
+import kr.co.ync.projectA.domain.restaurantHours.entity.RestaurantHoursEntity;
+import kr.co.ync.projectA.domain.restaurantHours.enums.DayOfWeekType;
+import kr.co.ync.projectA.domain.restaurantHours.repository.RestaurantHoursRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RestaurantHoursService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantHoursRepository restaurantHoursRepository;
+
+    // 요일별 운영 시간 조회
+    // GET /api/restaurants/{restaurantId}/hours
+    public List<RestaurantHoursResponse> getHours(Long restaurantId) {
+        List<RestaurantHoursEntity> hoursList =
+                restaurantHoursRepository.findByRestaurant_Id(restaurantId);
+
+        return hoursList.stream()
+                .map(RestaurantHoursResponse::fromEntity)
+                .toList();
+    }
+
+    // 요일별 운영 시간 등록 (초기 세팅)
+    // POST /api/restaurants/{restaurantId}/hours
+    @Transactional
+    public void initHours(Long restaurantId, List<RestaurantHoursRequest> requests) {
+        RestaurantEntity restaurant = restaurantRepository.findById(restaurantId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 레스토랑입니다. id=" + restaurantId));
+
+        // 이미 영업시간이 하나라도 있으면 초기 세팅 불가 (정책용)
+        boolean exists = !restaurantHoursRepository.findByRestaurant_Id(restaurantId).isEmpty();
+        if (exists) {
+            throw new IllegalStateException("이미 영업시간이 등록된 레스토랑입니다. 초기 세팅은 한 번만 가능합니다.");
+        }
+
+        List<RestaurantHoursEntity> entities = requests.stream()
+                .map(req -> RestaurantHoursEntity.builder()
+                        .restaurant(restaurant)
+                        .dayOfWeek(req.getDayOfWeek())
+                        .openTime(req.getOpenTime())
+                        .closeTime(req.getCloseTime())
+                        .isOpen(req.getIsOpen())
+                        .build()
+                )
+                .toList();
+
+        restaurantHoursRepository.saveAll(entities);
+    }
+
+    // 요일별 운영 시간 수정
+    // PUT /api/restaurants/{restaurantId}/hours/{dayOfWeek}
+    @Transactional
+    public RestaurantHoursResponse updateHours(
+            Long restaurantId,
+            DayOfWeekType dayOfWeek,
+            RestaurantHoursRequest request
+    ) {
+        RestaurantHoursEntity entity = restaurantHoursRepository
+                .findByRestaurant_IdAndDayOfWeek(restaurantId, dayOfWeek)
+                .orElseThrow(() -> new IllegalArgumentException("해당 요일의 영업시간이 존재하지 않습니다. restaurantId=" + restaurantId + ", dayOfWeek=" + dayOfWeek));
+
+        // request.getDayOfWeek()는 굳이 안 써도 됨. pathVariable 기준으로 처리.
+        entity.updateHours(
+                request.getOpenTime(),
+                request.getCloseTime(),
+                request.getIsOpen()
+        );
+
+        return RestaurantHoursResponse.fromEntity(entity);
+    }
+
+    // 요일별 운영 시간 활성/비활성 (휴무 설정)
+    // PATCH /api/restaurants/{restaurantId}/hours/{dayOfWeek}/active
+    @Transactional
+    public RestaurantHoursResponse updateActive(
+            Long restaurantId,
+            DayOfWeekType dayOfWeek,
+            RestaurantHoursActiveRequest request
+    ) {
+        RestaurantHoursEntity entity = restaurantHoursRepository
+                .findByRestaurant_IdAndDayOfWeek(restaurantId, dayOfWeek)
+                .orElseThrow(() -> new IllegalArgumentException("해당 요일의 영업시간이 존재하지 않습니다. restaurantId=" + restaurantId + ", dayOfWeek=" + dayOfWeek));
+
+        entity.updateActive(request.getIsOpen());
+
+        return RestaurantHoursResponse.fromEntity(entity);
+    }
+}


### PR DESCRIPTION
## 구현 내용
- Entity/enum
  - `RestaurantHoursEntity` 추가
    - 레스토랑(restaurant)와 N:1 관계
    - 요일(`dayOfWeek`), 오픈 시간(`openTime`), 마감 시간(`closeTime`), 운영 여부(`isOpen`) 필드 추가
    - `(restaurant_id, day_of_week)` 
  - `DayOfWeekType` enum 추가
    - 값: `MON, TUE, WED, THU, FRI, SAT, SUN`

- DTO
  - `RestaurantHoursRequest`
    - 요일별 영업시간 등록/수정 요청용 DTO
  - `RestaurantHoursActiveRequest`
    - 휴무/영업 활성화 전용 요청 DTO (`isOpen`만 포함)
  - `RestaurantHoursResponse`
    - 요일별 영업시간 조회 응답용 DTO 

- Repository
  - `RestaurantHoursRepository`
    - `findByRestaurant_Id(Long restaurantId)`
    - `findByRestaurant_IdAndDayOfWeek(Long restaurantId, DayOfWeekType dayOfWeek)`

- Service (`RestaurantHoursService`)
  - `getHours(Long restaurantId)`
    - 특정 레스토랑의 요일별 영업시간 전체 조회
  - `initHours(Long restaurantId, List<RestaurantHoursRequest> requests)`
    - 레스토랑 최초 등록 시 월~일까지 초기 영업시간 세팅
  - `updateHours(Long restaurantId, DayOfWeekType dayOfWeek, RestaurantHoursRequest request)`
    - 특정 요일의 오픈/마감 시간 및 운영 여부 수정
  - `updateActive(Long restaurantId, DayOfWeekType dayOfWeek, RestaurantHoursActiveRequest request)`
    - 특정 요일의 `isOpen` 플래그만 활성/비활성(휴무 설정) 변경
    
- Controller (`RestaurantHoursController`)
  - `GET   /api/restaurants/{restaurantId}/hours`
    - 요일별 영업시간 조회
  - `POST  /api/restaurants/{restaurantId}/hours`
    - 요일별 영업시간 초기 세팅(월~일 7개를 한 번에 등록하는 용도)
  - `PUT   /api/restaurants/{restaurantId}/hours/{dayOfWeek}`
    - 특정 요일의 영업시간 수정
  - `PATCH /api/restaurants/{restaurantId}/hours/{dayOfWeek}/active`
    - 특정 요일 영업/휴무 활성화 토글

## 관련 이슈
Closes #175 